### PR TITLE
Added Deadzone Functionality

### DIFF
--- a/Xb2XInput/Xb2XInput.cpp
+++ b/Xb2XInput/Xb2XInput.cpp
@@ -15,6 +15,9 @@ int poll_ms = (1000 / min(1000, poll_rate));
 // LT + RT + LS + RS to emulate guide button
 bool guideCombinationEnabled = true;
 
+// (LT | RT) + LS + RS + DPAD to change deadzone 
+bool deadzoneCombinationEnabled = true;
+
 // Vibration support
 bool vibrationEnabled = true;
 
@@ -119,6 +122,7 @@ bool StartupDeleteEntry()
 #define ID_TRAY_CONTROLLER 5006
 #define ID_TRAY_GUIDEBTN 5007
 #define ID_TRAY_VIBING 5008
+#define ID_TRAY_DEADZONE 5100
 
 WCHAR tray_text[128];
 
@@ -176,6 +180,19 @@ void SysTrayShowContextMenu()
   InsertMenu(hPopMenu, 0xFFFFFFFF, MF_BYPOSITION | MF_STRING |
     (StartupIsSet() ? MF_CHECKED : MF_UNCHECKED), ID_TRAY_STARTUP, L"Run on startup");
   InsertMenu(hPopMenu, 0xFFFFFFFF, MF_SEPARATOR, ID_TRAY_SEP, L"SEP");
+  InsertMenu(hPopMenu, 0xFFFFFFFF, MF_BYPOSITION | MF_STRING |
+    (deadzoneCombinationEnabled ? MF_CHECKED : MF_UNCHECKED), ID_TRAY_DEADZONE, L"Enable deadzone combination (LT|RT)+LS+RS+DPAD");
+
+  // Insert current deadzone adjustments into context menu
+  i = 0;
+  for (auto& controller : pads) {
+    i++;
+    auto dz = controller.GetDeadzone();
+    swprintf_s(ctl_text, L"Deadzone %d: L(%d) R(%d)",i, dz.sThumbL, dz.sThumbR);
+    InsertMenu(hPopMenu, 0xFFFFFFFF, MF_BYPOSITION | MF_STRING | MF_GRAYED, ID_TRAY_DEADZONE+i, ctl_text);
+  }
+  
+  InsertMenu(hPopMenu, 0xFFFFFFFF, MF_SEPARATOR, ID_TRAY_SEP, L"SEP");
   InsertMenu(hPopMenu, 0xFFFFFFFF, MF_BYPOSITION | MF_STRING, ID_TRAY_EXIT, L"Exit");
 
   SetForegroundWindow(hwnd);
@@ -210,6 +227,9 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
       break;
     case ID_TRAY_GUIDEBTN:
       guideCombinationEnabled = !guideCombinationEnabled;
+      break;
+    case ID_TRAY_DEADZONE:
+      deadzoneCombinationEnabled = !deadzoneCombinationEnabled;
       break;
     case ID_TRAY_VIBING:
       vibrationEnabled = !vibrationEnabled;

--- a/Xb2XInput/XboxController.hpp
+++ b/Xb2XInput/XboxController.hpp
@@ -58,6 +58,13 @@ struct XboxOutputReport {
 
   OGXINPUT_RUMBLE Rumble;
 };
+
+struct Deadzone {
+  short sThumbL;
+  short sThumbR;
+  bool hold; 
+};
+
 #pragma pack(pop)
 
 #define HID_GET_REPORT                0x01
@@ -90,6 +97,9 @@ class XboxController
   uint8_t endpoint_in_ = 0;
   uint8_t endpoint_out_ = 0;
 
+  Deadzone deadzone_ = {0};
+  int deadZoneCalc(short *x_out, short *y_out, short x, short y, short deadzone, short sickzone);
+
   bool update();
 public:
   XboxController(libusb_device_handle* handle, uint8_t* usb_ports, int num_ports);
@@ -98,7 +108,8 @@ public:
   int GetVendorId() const { return usb_vendor_; }
   const char* GetProductName() const { return usb_productname_; }
   const char* GetVendorName() const { return usb_vendorname_; }
-
+  Deadzone GetDeadzone() { return deadzone_; }
+  
   int GetControllerIndex()
   { 
     if (!target_)


### PR DESCRIPTION
Deadzone and adjustment button combination LT + RT + (LS or RS) + DPAD
UP/DN
has been added per controller. Current deadzone is displayed in the
context menu. The deadzone is implemented by mapping the remaining range
of the axis back to the range of 0 to SHRT_MAX. Left and Right analog
sticks can be adjusted individually and is determined by which analog
stick
is pressed down during the deadzone adjustment button combination.

TODO: It would be nice if the deadzone would be remembered by hardware
serial number and stored in the registry or elsewhere.