### PR TITLE
Improved Multi-Controller Reliability

### DIFF
--- a/Xb2XInput/XboxController.cpp
+++ b/Xb2XInput/XboxController.cpp
@@ -107,8 +107,8 @@ libusb_device_handle* XboxController::OpenDevice()
     if (exists)
       continue;
 
-    ret = libusb_open_device_with_vid_pid(NULL, desc.idVendor, desc.idProduct);
-    if (!ret)
+    // open USB device by libusb_device* returned from device list
+    if (libusb_open(devs[i],&ret))
       continue;
 
     auto controller = XboxController(ret, (uint8_t*)&usb_ports, num_ports);


### PR DESCRIPTION
Replaced the call to libusb_open_device_with_vid_pid() with libusb_open(). The former should not be used outside of a test application and has limitations such as only being able to open the first device with a matching vid/pid. This caused issues with multiple identical controllers, where only the first would be opened and the second would fail.